### PR TITLE
[carddav] Support addressbook-info responses to user-principal requests

### DIFF
--- a/src/carddav_p.h
+++ b/src/carddav_p.h
@@ -73,6 +73,7 @@ private:
     void fetchUserInformation();
     void fetchAddressbookUrls(const QString &userPath);
     void fetchAddressbooksInformation(const QString &addressbooksHomePath);
+    void downsyncAddressbookContent(const QList<ReplyParser::AddressBookInformation> &infos);
     void fetchImmediateDelta(const QString &addressbookUrl, const QString &syncToken);
     void fetchContactMetadata(const QString &addressbookUrl);
     void fetchContacts(const QString &addressbookUrl, const QList<ReplyParser::ContactInformation> &amrInfo);

--- a/src/replyparser_p.h
+++ b/src/replyparser_p.h
@@ -67,10 +67,17 @@ public:
         QString etag;
     };
 
+    enum ResponseType {
+        UserPrincipalResponse = 0,
+        AddressbookHomeResponse,
+        AddressbookInformationResponse,
+        ContactDataResponse
+    };
+
     ReplyParser(Syncer *parent, CardDavVCardConverter *converter);
     ~ReplyParser();
 
-    QString parseUserPrinciple(const QByteArray &userInformationResponse) const;
+    QString parseUserPrincipal(const QByteArray &userInformationResponse, ResponseType *responseType) const;
     QString parseAddressbookHome(const QByteArray &addressbookUrlsResponse) const;
     QList<AddressBookInformation> parseAddressbookInformation(const QByteArray &addressbookInformationResponse) const;
     QList<ContactInformation> parseSyncTokenDelta(const QByteArray &syncTokenDeltaResponse, QString *newSyncToken) const;


### PR DESCRIPTION
Some CardDAV server implementations do not return the expected response
to user-principal requests, but instead return addressbook-info data.
This commit adds detection for that case and skips the intermediate
discovery steps when such a response is returned by the server.

Also, some CardDAV server implementations return a propfind request
response which includes information for the addressbook resource,
as well as any contact resources within that addressbook.  This commit
adds code to detect that case and ignore the result data for the
addressbook resource which is spurious.

Together, these changes add support for Memotoo CardDAV server.
