### PR TITLE
consider addressbook_path setting

### DIFF
--- a/src/carddav.cpp
+++ b/src/carddav.cpp
@@ -231,6 +231,7 @@ void CardDavVCardConverter::detailProcessed(const QContact &, const QContactDeta
 
 CardDav::CardDav(Syncer *parent,
                  const QString &serverUrl,
+                 const QString &addressbookPath,
                  const QString &username,
                  const QString &password)
     : QObject(parent)
@@ -239,6 +240,7 @@ CardDav::CardDav(Syncer *parent,
     , m_request(new RequestGenerator(q, username, password))
     , m_parser(new ReplyParser(q, m_converter))
     , m_serverUrl(serverUrl)
+    , m_addressbookPath(addressbookPath)
     , m_downsyncRequests(0)
     , m_upsyncRequests(0)
 {
@@ -246,6 +248,7 @@ CardDav::CardDav(Syncer *parent,
 
 CardDav::CardDav(Syncer *parent,
                  const QString &serverUrl,
+                 const QString &addressbookPath,
                  const QString &accessToken)
     : QObject(parent)
     , q(parent)
@@ -253,6 +256,7 @@ CardDav::CardDav(Syncer *parent,
     , m_request(new RequestGenerator(q, accessToken))
     , m_parser(new ReplyParser(q, m_converter))
     , m_serverUrl(serverUrl)
+    , m_addressbookPath(addressbookPath)
     , m_downsyncRequests(0)
     , m_upsyncRequests(0)
 {
@@ -288,7 +292,7 @@ void CardDav::determineRemoteAMR()
 void CardDav::fetchUserInformation()
 {
     LOG_DEBUG(Q_FUNC_INFO << "requesting principal urls for user");
-    QNetworkReply *reply = m_request->currentUserInformation(m_serverUrl);
+    QNetworkReply *reply = m_request->currentUserInformation(m_serverUrl, m_addressbookPath);
     if (!reply) {
         emit error();
         return;

--- a/src/carddav_p.h
+++ b/src/carddav_p.h
@@ -49,10 +49,12 @@ class CardDav : public QObject
 public:
     CardDav(Syncer *parent,
             const QString &serverUrl,
+            const QString &addressbookPath,
             const QString &username,
             const QString &password);
     CardDav(Syncer *parent,
             const QString &serverUrl,
+            const QString &addressbookPath,
             const QString &accessToken);
     ~CardDav();
 
@@ -97,6 +99,7 @@ private:
     RequestGenerator *m_request;
     ReplyParser *m_parser;
     QString m_serverUrl;
+    QString m_addressbookPath;
 
     QList<QContact> m_remoteAdditions;
     QList<QContact> m_remoteModifications;

--- a/src/requestgenerator.cpp
+++ b/src/requestgenerator.cpp
@@ -132,7 +132,7 @@ QNetworkReply *RequestGenerator::generateUpsyncRequest(const QString &url,
     return q->m_qnam.sendCustomRequest(req, requestType.toLatin1());
 }
 
-QNetworkReply *RequestGenerator::currentUserInformation(const QString &serverUrl)
+QNetworkReply *RequestGenerator::currentUserInformation(const QString &serverUrl, const QString &addressbookPath)
 {
     if (Q_UNLIKELY(serverUrl.isEmpty())) {
         LOG_WARNING(Q_FUNC_INFO << "server url empty, aborting");
@@ -146,7 +146,7 @@ QNetworkReply *RequestGenerator::currentUserInformation(const QString &serverUrl
           "</d:prop>"
         "</d:propfind>");
 
-    return generateRequest(serverUrl, QString(), QLatin1String("0"), QLatin1String("PROPFIND"), requestStr);
+    return generateRequest(serverUrl, addressbookPath, QLatin1String("0"), QLatin1String("PROPFIND"), requestStr);
 }
 
 QNetworkReply *RequestGenerator::addressbookUrls(const QString &serverUrl, const QString &userPath)

--- a/src/requestgenerator_p.h
+++ b/src/requestgenerator_p.h
@@ -39,7 +39,7 @@ public:
     RequestGenerator(Syncer *parent, const QString &username, const QString &password);
     RequestGenerator(Syncer *parent, const QString &accessToken);
 
-    QNetworkReply *currentUserInformation(const QString &serverUrl);
+    QNetworkReply *currentUserInformation(const QString &serverUrl, const QString &addressbookPath);
     QNetworkReply *addressbookUrls(const QString &serverUrl, const QString &userPath);
     QNetworkReply *addressbooksInformation(const QString &serverUrl, const QString &userAddressbooksPath);
     QNetworkReply *addressbookInformation(const QString &serverUrl, const QString &addressbookPath);

--- a/src/syncer_p.h
+++ b/src/syncer_p.h
@@ -37,6 +37,8 @@
 #include <QContactManager>
 #include <QContact>
 
+#include <Accounts/Manager>
+
 QTCONTACTS_USE_NAMESPACE
 
 class Auth;
@@ -97,6 +99,8 @@ private:
     QString m_username;
     QString m_password;
     QString m_accessToken;
+    QString m_addressbookPath;
+    Accounts::Manager* mManager;
 
     // transient
     QString m_defaultAddressbook;


### PR DESCRIPTION
With this patch, the plugin considers the addressbook_path string in the account settings and enables synchronization with owncloud (from owndrive.com) for me. For now, this string cannot be set using the Jolla account manager but has to be set manually using a terminal. This might also be interesting for https://github.com/nemomobile/buteo-sync-plugin-carddav/issues/4 . However, only the first sync works so far, unfortunately.

If someone is interested to test the patch:
1. Install the patched package. If someone hasn't set up a build environment: [buteo-sync-plugin-carddav-0.0.6-1.armv7hl.rpm](http://kicherer.org/stuff/buteo-sync-plugin-carddav-0.0.6-1.armv7hl.rpm) (d1558ac54c1b7a0f7007c6b05fde3c49)
2. Setup the carddav account (ensure that the server setting has no trailing "/").
3. Get the ID of the new account using ```ag-tool list-accounts```
4. Set addressbook_path using ```ag-tool update-service $your_id onlinesync-carddav string:addressbook_path=remote.php/carddav/addressbooks/$your_user/$your_addressbook```
5. Sync your account