### PR TITLE
[carddav] Improve URL path repetition detection logic

### DIFF
--- a/rpm/buteo-sync-plugin-carddav.spec
+++ b/rpm/buteo-sync-plugin-carddav.spec
@@ -1,6 +1,6 @@
 Name:       buteo-sync-plugin-carddav
 Summary:    Syncs calendar data from CardDAV services
-Version:    0.0.6
+Version:    0.0.7
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1

--- a/src/requestgenerator.cpp
+++ b/src/requestgenerator.cpp
@@ -59,9 +59,12 @@ QNetworkReply *RequestGenerator::generateRequest(const QString &url,
                                                  const QString &request) const
 {
     QByteArray requestData(request.toUtf8());
-    QUrl reqUrl = url.endsWith(path)
-                ? QUrl(url)
-                : QUrl(QStringLiteral("%1/%2").arg(url).arg(path));
+    QUrl reqUrl(url);
+    if (reqUrl.path().isEmpty() || path.startsWith(reqUrl.path())) {
+        reqUrl.setPath(path);
+    } else {
+        reqUrl.setPath(QStringLiteral("%1/%2").arg(reqUrl.path()).arg(path));
+    }
     if (!m_username.isEmpty() && !m_password.isEmpty()) {
         reqUrl.setUserName(m_username);
         reqUrl.setPassword(m_password);
@@ -97,9 +100,12 @@ QNetworkReply *RequestGenerator::generateUpsyncRequest(const QString &url,
                                                        const QString &request) const
 {
     QByteArray requestData(request.toUtf8());
-    QUrl reqUrl = url.endsWith(path)
-                ? QUrl(url)
-                : QUrl(QStringLiteral("%1/%2").arg(url).arg(path));
+    QUrl reqUrl(url);
+    if (reqUrl.path().isEmpty() || path.startsWith(reqUrl.path())) {
+        reqUrl.setPath(path);
+    } else {
+        reqUrl.setPath(QStringLiteral("%1/%2").arg(reqUrl.path()).arg(path));
+    }
     if (!m_username.isEmpty() && !m_password.isEmpty()) {
         reqUrl.setUserName(m_username);
         reqUrl.setPassword(m_password);


### PR DESCRIPTION
Some services (such as self-hosted OwnCloud servers) have a base url
which includes both a host and a path segment.  When performing later
requests to another path (e.g., a user principals url request), we
need to ensure that we do not duplicate the suffix path-segment from
the base url, as it may already appear as a prefix in the request-path.

e.g.:
baseUrl: http://my.oc.tld/owncloud/remote.php/carddav
request: /owncloud/remote.php/carddav/principals/fred
result:  http://my.oc.tld/owncloud/remote.php/carddav/principals/fred