### PR TITLE
[carddav] Improve bootstrapping procedure

### DIFF
--- a/src/carddav_p.h
+++ b/src/carddav_p.h
@@ -70,7 +70,7 @@ Q_SIGNALS:
     void upsyncCompleted();
 
 private:
-    void fetchUserInformation(bool firstTime);
+    void fetchUserInformation();
     void fetchAddressbookUrls(const QString &userPath);
     void fetchAddressbooksInformation(const QString &addressbooksHomePath);
     void downsyncAddressbookContent(const QList<ReplyParser::AddressBookInformation> &infos);
@@ -92,11 +92,19 @@ private Q_SLOTS:
 
 private:
     void contactAddModsComplete(const QString &addressbookUrl);
+
+    enum DiscoveryStage {
+        DiscoveryStarted = 0,
+        DiscoveryRedirected,
+        DiscoveryTryRoot
+    };
+
     Syncer *q;
     CardDavVCardConverter *m_converter;
     RequestGenerator *m_request;
     ReplyParser *m_parser;
     QString m_serverUrl;
+    DiscoveryStage m_discoveryStage;
 
     QList<QContact> m_remoteAdditions;
     QList<QContact> m_remoteModifications;


### PR DESCRIPTION
This commit improves the bootstrapping procedure to follow RFC 6764.
The steps it follows are:
1) try the given server url (including path)
2) if fails, try the well-known endpoint
3) if fails, try the root URI
3) if fails, abort.