### PR TITLE
[carddav] Update to libaccounts-qt version 1.13

### DIFF
--- a/rpm/buteo-sync-plugin-carddav.spec
+++ b/rpm/buteo-sync-plugin-carddav.spec
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(buteosyncfw5)
-BuildRequires:  pkgconfig(accounts-qt5)
+BuildRequires:  pkgconfig(accounts-qt5) >= 1.13
 BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
 BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions)

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -59,7 +59,7 @@ Auth::~Auth()
 
 void Auth::signIn(int accountId)
 {
-    m_account = m_manager.account(accountId);
+    m_account = Accounts::Account::fromId(&m_manager, accountId, this);
     if (!m_account) {
         LOG_WARNING(Q_FUNC_INFO << "unable to load account" << accountId);
         emit signInError();


### PR DESCRIPTION
This commit ensures that we use the Accounts::Account::fromId()
function instead of the Accounts::Manager::account() function to
retrieve any account instance whose lifetime we intend to explicitly
control, as the latter function was updated between version 1.6 and
1.7 of libaccounts-qt so that it is now unsafe to delete the
returned value.