### PR TITLE
[buteo-sync-plugin-carddav] Support importing PHOTO properties

### DIFF
--- a/rpm/buteo-sync-plugin-carddav.spec
+++ b/rpm/buteo-sync-plugin-carddav.spec
@@ -19,6 +19,7 @@ BuildRequires:  pkgconfig(accounts-qt5) >= 1.13
 BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
 BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions)
+BuildRequires:  pkgconfig(contactcache-qt5)
 Requires: buteo-syncfw-qt5-msyncd
 
 %description

--- a/src/src.pro
+++ b/src/src.pro
@@ -5,7 +5,7 @@ QT       += network dbus
 
 CONFIG += link_pkgconfig console
 PKGCONFIG += buteosyncfw5 libsignon-qt5 accounts-qt5 libsailfishkeyprovider
-PKGCONFIG += Qt5Versit Qt5Contacts qtcontacts-sqlite-qt5-extensions
+PKGCONFIG += Qt5Versit Qt5Contacts qtcontacts-sqlite-qt5-extensions contactcache-qt5
 QT += contacts-private
 
 QMAKE_CXXFLAGS = -Wall \


### PR DESCRIPTION
This commit adds support for importing PHOTO properties as avatar
details, using the standard Seaside libcontacts PHOTO handler.