### PR TITLE
[buteo-sync-plugin-carddav] Support ignoring SSL errors

### DIFF
--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -45,6 +45,7 @@ Auth::Auth(QObject *parent)
     , m_account(0)
     , m_ident(0)
     , m_session(0)
+    , m_ignoreSslErrors(false)
 {
 }
 
@@ -84,6 +85,7 @@ void Auth::signIn(int accountId)
 
     // determine the remote server URL from the account settings, and then sign in.
     m_account->selectService(srv);
+    m_ignoreSslErrors = m_account->value("ignore_ssl_errors").toBool();
     m_serverUrl = m_account->value("server_address").toString();
     if (m_serverUrl.isEmpty()) {
         LOG_WARNING(Q_FUNC_INFO << "no valid server url setting in account" << accountId);
@@ -151,9 +153,9 @@ void Auth::signOnResponse(const SignOn::SessionData &response)
 
     // we need both username+password, OR accessToken.
     if (!accessToken.isEmpty()) {
-        emit signInCompleted(m_serverUrl, QString(), QString(), accessToken);
+        emit signInCompleted(m_serverUrl, QString(), QString(), accessToken, m_ignoreSslErrors);
     } else if (!username.isEmpty() && !password.isEmpty()) {
-        emit signInCompleted(m_serverUrl, username, password, QString());
+        emit signInCompleted(m_serverUrl, username, password, QString(), m_ignoreSslErrors);
     } else {
         LOG_WARNING(Q_FUNC_INFO << "authentication succeeded, but couldn't find valid credentials");
         emit signInError();

--- a/src/auth_p.h
+++ b/src/auth_p.h
@@ -43,7 +43,7 @@ public:
     void setCredentialsNeedUpdate(int accountId);
 
 Q_SIGNALS:
-    void signInCompleted(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken);
+    void signInCompleted(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors);
     void signInError();
 
 private Q_SLOTS:
@@ -56,6 +56,7 @@ private:
     SignOn::Identity *m_ident;
     SignOn::AuthSession *m_session;
     QString m_serverUrl;
+    bool m_ignoreSslErrors;
 };
 
 

--- a/src/carddav.cpp
+++ b/src/carddav.cpp
@@ -330,7 +330,20 @@ void CardDav::fetchUserInformation()
         return;
     }
 
+    connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
     connect(reply, SIGNAL(finished()), this, SLOT(userInformationResponse()));
+}
+
+void CardDav::sslErrorsOccurred(const QList<QSslError> &errors)
+{
+    QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
+    if (q->m_ignoreSslErrors) {
+        LOG_DEBUG(Q_FUNC_INFO << "ignoring SSL errors due to account policy:" << errors);
+        reply->ignoreSslErrors(errors);
+    } else {
+        LOG_WARNING(Q_FUNC_INFO << "SSL errors occurred, aborting:" << errors);
+        errorOccurred(401);
+    }
 }
 
 void CardDav::userInformationResponse()
@@ -426,6 +439,7 @@ void CardDav::fetchAddressbookUrls(const QString &userPath)
         return;
     }
 
+    connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
     connect(reply, SIGNAL(finished()), this, SLOT(addressbookUrlsResponse()));
 }
 
@@ -461,6 +475,7 @@ void CardDav::fetchAddressbooksInformation(const QString &addressbooksHomePath)
         return;
     }
 
+    connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
     connect(reply, SIGNAL(finished()), this, SLOT(addressbooksInformationResponse()));
 }
 
@@ -561,6 +576,7 @@ void CardDav::fetchImmediateDelta(const QString &addressbookUrl, const QString &
 
     m_downsyncRequests += 1; // when this reaches zero, we've finished all addressbook deltas
     reply->setProperty("addressbookUrl", addressbookUrl);
+    connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
     connect(reply, SIGNAL(finished()), this, SLOT(immediateDeltaResponse()));
 }
 
@@ -596,6 +612,7 @@ void CardDav::fetchContactMetadata(const QString &addressbookUrl)
 
     m_downsyncRequests += 1; // when this reaches zero, we've finished all addressbook deltas
     reply->setProperty("addressbookUrl", addressbookUrl);
+    connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
     connect(reply, SIGNAL(finished()), this, SLOT(contactMetadataResponse()));
 }
 
@@ -659,6 +676,7 @@ void CardDav::fetchContacts(const QString &addressbookUrl, const QList<ReplyPars
         }
 
         reply->setProperty("addressbookUrl", addressbookUrl);
+        connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
         connect(reply, SIGNAL(finished()), this, SLOT(contactsResponse()));
     }
 }
@@ -823,6 +841,7 @@ void CardDav::upsyncUpdates(const QString &addressbookUrl, const QList<QContact>
             m_upsyncRequests += 1;
             reply->setProperty("addressbookUrl", addressbookUrl);
             reply->setProperty("contactGuid", guid);
+            connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
             connect(reply, SIGNAL(finished()), this, SLOT(upsyncResponse()));
         }
 
@@ -857,6 +876,7 @@ void CardDav::upsyncUpdates(const QString &addressbookUrl, const QList<QContact>
             m_upsyncRequests += 1;
             reply->setProperty("addressbookUrl", addressbookUrl);
             reply->setProperty("contactGuid", guidstr);
+            connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
             connect(reply, SIGNAL(finished()), this, SLOT(upsyncResponse()));
         }
 
@@ -880,6 +900,7 @@ void CardDav::upsyncUpdates(const QString &addressbookUrl, const QList<QContact>
 
             m_upsyncRequests += 1;
             reply->setProperty("addressbookUrl", addressbookUrl);
+            connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrorsOccurred(QList<QSslError>)));
             connect(reply, SIGNAL(finished()), this, SLOT(upsyncResponse()));
         }
     }

--- a/src/carddav_p.h
+++ b/src/carddav_p.h
@@ -32,6 +32,7 @@
 #include <QMap>
 #include <QString>
 #include <QSet>
+#include <QSslError>
 
 #include <QContact>
 #include <QVersitContactImporterPropertyHandlerV2>
@@ -79,6 +80,7 @@ private:
     void fetchContacts(const QString &addressbookUrl, const QList<ReplyParser::ContactInformation> &amrInfo);
 
 private Q_SLOTS:
+    void sslErrorsOccurred(const QList<QSslError> &errors);
     void userInformationResponse();
     void addressbookUrlsResponse();
     void addressbooksInformationResponse();

--- a/src/syncer.cpp
+++ b/src/syncer.cpp
@@ -58,6 +58,7 @@ Syncer::Syncer(QObject *parent, Buteo::SyncProfile *syncProfile)
     , m_syncProfile(syncProfile)
     , m_cardDav(0)
     , m_auth(0)
+    , m_ignoreSslErrors(false)
 {
 }
 
@@ -77,8 +78,8 @@ void Syncer::startSync(int accountId)
     Q_ASSERT(accountId != 0);
     m_accountId = accountId;
     m_auth = new Auth(this);
-    connect(m_auth, SIGNAL(signInCompleted(QString,QString,QString,QString)),
-            this, SLOT(sync(QString,QString,QString,QString)));
+    connect(m_auth, SIGNAL(signInCompleted(QString,QString,QString,QString,bool)),
+            this, SLOT(sync(QString,QString,QString,QString,bool)));
     connect(m_auth, SIGNAL(signInError()),
             this, SLOT(signInError()));
     LOG_DEBUG(Q_FUNC_INFO << "starting carddav sync with account" << m_accountId);
@@ -90,12 +91,13 @@ void Syncer::signInError()
     emit syncFailed();
 }
 
-void Syncer::sync(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken)
+void Syncer::sync(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors)
 {
     m_serverUrl = serverUrl;
     m_username = username;
     m_password = password;
     m_accessToken = accessToken;
+    m_ignoreSslErrors = ignoreSslErrors;
 
     QDateTime remoteSince;
     if (!initSyncAdapter(QString::number(m_accountId))

--- a/src/syncer_p.h
+++ b/src/syncer_p.h
@@ -75,7 +75,7 @@ private:
     bool storeExtraStateData(int accountId);
 
 private Q_SLOTS:
-    void sync(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken);
+    void sync(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors);
     void continueSync(const QList<QContact> &added, const QList<QContact> &modified, const QList<QContact> &removed);
     void syncFinished();
     void signInError();
@@ -97,6 +97,7 @@ private:
     QString m_username;
     QString m_password;
     QString m_accessToken;
+    bool m_ignoreSslErrors;
 
     // transient
     QString m_defaultAddressbook;


### PR DESCRIPTION
This commit now ensures that the user-selected policy toward SSL
errors is respected, by ignoring SSL errors if required.
That policy comes from the ignore_ssl_errors account setting.