### PR TITLE
[buteo-sync-plugin-carddav] Ensure that synced details are modifiable

### DIFF
--- a/src/carddav.cpp
+++ b/src/carddav.cpp
@@ -123,6 +123,12 @@ QPair<QContact, QStringList> CardDavVCardConverter::convertVCardToContact(const 
     QStringList unsupportedProperties = m_unsupportedProperties.value(importedContact.detail<QContactGuid>().guid());
     m_unsupportedProperties.clear();
 
+    // mark each detail of the contact as modifiable
+    Q_FOREACH (QContactDetail det, importedContact.details()) {
+        det.setValue(QContactDetail__FieldModifiable, true);
+        importedContact.saveDetail(&det);
+    }
+
     *ok = true;
     return qMakePair(importedContact, unsupportedProperties);
 }


### PR DESCRIPTION
This commit marks all synced contact details as modifiable, so that
the user can modify them on the device.