### PR TITLE
[buteo-sync-plugin-carddav] Add rudimentary connection-loss handling

### DIFF
--- a/src/carddavclient.cpp
+++ b/src/carddavclient.cpp
@@ -59,6 +59,10 @@ void CardDavClient::connectivityStateChanged(Sync::ConnectivityType aType, bool 
 {
     FUNCTION_CALL_TRACE;
     LOG_DEBUG("Received connectivity change event:" << aType << " changed to " << aState);
+    if (aType == Sync::CONNECTIVITY_INTERNET && !aState) {
+        // we lost connectivity during sync.
+        abortSync(Sync::SYNC_CONNECTION_ERROR);
+    }
 }
 
 bool CardDavClient::init()
@@ -120,6 +124,7 @@ void CardDavClient::abortSync(Sync::SyncStatus aStatus)
 void CardDavClient::abort(Sync::SyncStatus status)
 {
     FUNCTION_CALL_TRACE;
+    m_syncer->abortSync();
     syncFinished(status, QStringLiteral("Sync aborted"));
 }
 

--- a/src/syncer_p.h
+++ b/src/syncer_p.h
@@ -54,6 +54,7 @@ public:
 
     void startSync(int accountId);
     void purgeAccount(int accountId);
+    void abortSync();
 
 Q_SIGNALS:
     void syncSucceeded();
@@ -90,6 +91,7 @@ private:
     Auth *m_auth;
     QContactManager m_contactManager;
     QNetworkAccessManager m_qnam;
+    bool m_syncAborted;
 
     // auth related
     int m_accountId;


### PR DESCRIPTION
This commit adds code to handle connection-loss during sync by aborting
prior to writing data to the database.