### PR TITLE
[carddav] Improve error handling. Contributes to MER#941

### DIFF
--- a/rpm/buteo-sync-plugin-carddav.spec
+++ b/rpm/buteo-sync-plugin-carddav.spec
@@ -18,7 +18,7 @@ BuildRequires:  pkgconfig(buteosyncfw5)
 BuildRequires:  pkgconfig(accounts-qt5) >= 1.13
 BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions)
+BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.2.18
 BuildRequires:  pkgconfig(contactcache-qt5)
 Requires: buteo-syncfw-qt5-msyncd
 

--- a/src/carddav.cpp
+++ b/src/carddav.cpp
@@ -952,7 +952,13 @@ void CardDav::upsyncResponse()
         }
 
         if (!etag.isEmpty()) {
+            LOG_DEBUG("Got updated etag for" << guid << ":" << etag);
             q->m_contactEtags[guid] = etag;
+        } else {
+            // If we don't perform an additional request, the etag server-side will be different to the etag
+            // we have locally, and thus on next sync we would spuriously detect a server-side modification.
+            // That's ok, we'll just detect that it's spurious via data inspection during the next sync.
+            LOG_WARNING("No updated etag provided for" << guid << ": will be reported as spurious remote modification next sync");
         }
     }
 

--- a/src/requestgenerator.cpp
+++ b/src/requestgenerator.cpp
@@ -134,6 +134,9 @@ QNetworkReply *RequestGenerator::generateUpsyncRequest(const QString &url,
     }
 
     LOG_DEBUG("generateUpsyncRequest():" << m_accessToken << reqUrl << ":" << requestData.length() << "bytes");
+    Q_FOREACH (const QByteArray &headerName, req.rawHeaderList()) {
+        LOG_DEBUG("   " << headerName << "=" << req.rawHeader(headerName));
+    }
 
     if (!request.isEmpty()) {
         QBuffer *requestDataBuffer = new QBuffer(q);

--- a/src/syncer.cpp
+++ b/src/syncer.cpp
@@ -59,6 +59,7 @@ Syncer::Syncer(QObject *parent, Buteo::SyncProfile *syncProfile)
     , m_cardDav(0)
     , m_auth(0)
     , m_syncAborted(false)
+    , m_syncError(false)
     , m_accountId(0)
     , m_ignoreSslErrors(false)
 {
@@ -115,6 +116,7 @@ void Syncer::sync(const QString &serverUrl, const QString &username, const QStri
         return;
     }
 
+    LOG_DEBUG("Sync adapter initialised, determining remote changes since" << remoteSince.toString(Qt::ISODate) << "for account" << m_accountId);
     determineRemoteChanges(remoteSince, QString::number(m_accountId));
 }
 
@@ -132,19 +134,10 @@ void Syncer::determineRemoteChanges(const QDateTime &, const QString &)
     m_cardDav->determineRemoteAMR();
 }
 
-void Syncer::cardDavError(int errorCode)
-{
-    if (errorCode == HTTP_UNAUTHORIZED_ACCESS) {
-        m_auth->setCredentialsNeedUpdate(m_accountId);
-    }
-    purgeSyncStateData(QString::number(m_accountId));   
-    emit syncFailed();
-}
-
 void Syncer::continueSync(const QList<QContact> &added, const QList<QContact> &modified, const QList<QContact> &removed)
 {
-    if (m_syncAborted) {
-        LOG_WARNING(Q_FUNC_INFO << "sync aborted");
+    if (m_syncAborted || m_syncError) {
+        LOG_WARNING(Q_FUNC_INFO << "sync error or aborted");
         cardDavError();
         return;
     }
@@ -190,7 +183,7 @@ void Syncer::continueSync(const QList<QContact> &added, const QList<QContact> &m
     }
 }
 
-void Syncer::upsyncLocalChanges(const QDateTime &,
+void Syncer::upsyncLocalChanges(const QDateTime &localSince,
                                 const QList<QContact> &locallyAdded,
                                 const QList<QContact> &locallyModified,
                                 const QList<QContact> &locallyDeleted,
@@ -198,7 +191,7 @@ void Syncer::upsyncLocalChanges(const QDateTime &,
 {
     LOG_DEBUG(Q_FUNC_INFO << "upsyncing local changes to remote server: AMR:"
              << locallyAdded.count() << locallyModified.count() << locallyDeleted.count()
-             << "for account:" << m_accountId);
+             << "for account:" << m_accountId << "since:" << localSince);
 
     // segment the changes according to the addressbook the contacts are from
     QSet<QString> modifiedAddressbookUrls;
@@ -261,16 +254,29 @@ void Syncer::upsyncLocalChanges(const QDateTime &,
 void Syncer::syncFinished()
 {
     // finished upsync.  Just need to store our state data and we're done.
+    LOG_DEBUG(Q_FUNC_INFO << "about to store sync state data");
     if (!storeExtraStateData(m_accountId) || !storeSyncStateData(QString::number(m_accountId))) {
         LOG_WARNING(Q_FUNC_INFO << "unable to finalise sync state");
         cardDavError(); // actually in this case we have already stored stuff to local and server...?
         return;
     }
 
-    LOG_DEBUG(Q_FUNC_INFO << "carddav sync with account" << m_accountId << "finished successfully!");
-
     // Success.
+    LOG_DEBUG(Q_FUNC_INFO << "carddav sync with account" << m_accountId << "finished successfully!");
     emit syncSucceeded();
+}
+
+void Syncer::cardDavError(int errorCode)
+{
+    LOG_WARNING("CardDAV sync finished with error:" << errorCode <<
+                "purging state data for account:" << m_accountId);
+    m_syncError = true;
+    if (errorCode == HTTP_UNAUTHORIZED_ACCESS) {
+        m_auth->setCredentialsNeedUpdate(m_accountId);
+    }
+    purgeExtraStateData(m_accountId);
+    purgeSyncStateData(QString::number(m_accountId));
+    emit syncFailed();
 }
 
 void Syncer::purgeAccount(int accountId)
@@ -567,5 +573,20 @@ bool Syncer::storeExtraStateData(int accountId)
         return false;
     }
 
+    return true;
+}
+
+// this function must be called directly before purgeSyncStateData()
+bool Syncer::purgeExtraStateData(int accountId)
+{
+    QStringList purgeKeys;
+    purgeKeys << QStringLiteral("addressbookContactGuids") << QStringLiteral("addressbookCtags");
+    purgeKeys << QStringLiteral("addressbookSyncTokens") << QStringLiteral("contactUids");
+    purgeKeys << QStringLiteral("contactUris") << QStringLiteral("contactEtags");
+    purgeKeys << QStringLiteral("contactIds") << QStringLiteral("contactUnsupportedProperties");
+    if (!d->m_engine->removeOOB(d->m_stateData[QString::number(accountId)].m_oobScope, purgeKeys)) {
+        LOG_WARNING(Q_FUNC_INFO << "failed to remove extra state data for carddav account" << accountId);
+        return false;
+    }
     return true;
 }

--- a/src/syncer_p.h
+++ b/src/syncer_p.h
@@ -74,6 +74,7 @@ protected:
 private:
     bool readExtraStateData(int accountId);
     bool storeExtraStateData(int accountId);
+    bool purgeExtraStateData(int accountId);
 
 private Q_SLOTS:
     void sync(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors);
@@ -92,6 +93,7 @@ private:
     QContactManager m_contactManager;
     QNetworkAccessManager m_qnam;
     bool m_syncAborted;
+    bool m_syncError;
 
     // auth related
     int m_accountId;


### PR DESCRIPTION
This commit ensures that all state data (including the extra state
data) is purged when required.

Previously, only the default state data was cleared, which would
result in sync artifacts being left in the out-of-band database.
On subsequent syncs, local updates would be ignored (because the
localSince value WAS cleared) but the remote data would be unchanged
(due to the ctags/extra state data remaining from previously).

Now, the local updates will be deliberately reverted upon next
sync after an error occurs (ie, PreferRemote conflict semantics),
and subsequent server-side changes will be respected.

Contributes to MER#941