### PR TITLE
[buteo-sync-plugin-carddav] Skip path discovery if addressbook home path is given. Contributes to MER#957

### DIFF
--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -83,10 +83,11 @@ void Auth::signIn(int accountId)
         return;
     }
 
-    // determine the remote server URL from the account settings, and then sign in.
+    // determine the remote URL from the account settings, and then sign in.
     m_account->selectService(srv);
     m_ignoreSslErrors = m_account->value("ignore_ssl_errors").toBool();
     m_serverUrl = m_account->value("server_address").toString();
+    m_addressbookPath = m_account->value("addressbook_path").toString(); // optional, may be empty.
     if (m_serverUrl.isEmpty()) {
         LOG_WARNING(Q_FUNC_INFO << "no valid server url setting in account" << accountId);
         emit signInError();
@@ -153,9 +154,9 @@ void Auth::signOnResponse(const SignOn::SessionData &response)
 
     // we need both username+password, OR accessToken.
     if (!accessToken.isEmpty()) {
-        emit signInCompleted(m_serverUrl, QString(), QString(), accessToken, m_ignoreSslErrors);
+        emit signInCompleted(m_serverUrl, m_addressbookPath, QString(), QString(), accessToken, m_ignoreSslErrors);
     } else if (!username.isEmpty() && !password.isEmpty()) {
-        emit signInCompleted(m_serverUrl, username, password, QString(), m_ignoreSslErrors);
+        emit signInCompleted(m_serverUrl, m_addressbookPath, username, password, QString(), m_ignoreSslErrors);
     } else {
         LOG_WARNING(Q_FUNC_INFO << "authentication succeeded, but couldn't find valid credentials");
         emit signInError();

--- a/src/auth_p.h
+++ b/src/auth_p.h
@@ -43,7 +43,7 @@ public:
     void setCredentialsNeedUpdate(int accountId);
 
 Q_SIGNALS:
-    void signInCompleted(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors);
+    void signInCompleted(const QString &serverUrl, const QString &addressbookPath, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors);
     void signInError();
 
 private Q_SLOTS:
@@ -56,6 +56,7 @@ private:
     SignOn::Identity *m_ident;
     SignOn::AuthSession *m_session;
     QString m_serverUrl;
+    QString m_addressbookPath;
     bool m_ignoreSslErrors;
 };
 

--- a/src/carddav_p.h
+++ b/src/carddav_p.h
@@ -50,10 +50,12 @@ class CardDav : public QObject
 public:
     CardDav(Syncer *parent,
             const QString &serverUrl,
+            const QString &addressbookPath,
             const QString &username,
             const QString &password);
     CardDav(Syncer *parent,
             const QString &serverUrl,
+            const QString &addressbookPath,
             const QString &accessToken);
     ~CardDav();
 
@@ -106,6 +108,7 @@ private:
     RequestGenerator *m_request;
     ReplyParser *m_parser;
     QString m_serverUrl;
+    QString m_addressbookPath;
     DiscoveryStage m_discoveryStage;
 
     QList<QContact> m_remoteAdditions;

--- a/src/syncer.cpp
+++ b/src/syncer.cpp
@@ -86,8 +86,8 @@ void Syncer::startSync(int accountId)
     Q_ASSERT(accountId != 0);
     m_accountId = accountId;
     m_auth = new Auth(this);
-    connect(m_auth, SIGNAL(signInCompleted(QString,QString,QString,QString,bool)),
-            this, SLOT(sync(QString,QString,QString,QString,bool)));
+    connect(m_auth, SIGNAL(signInCompleted(QString,QString,QString,QString,QString,bool)),
+            this, SLOT(sync(QString,QString,QString,QString,QString,bool)));
     connect(m_auth, SIGNAL(signInError()),
             this, SLOT(signInError()));
     LOG_DEBUG(Q_FUNC_INFO << "starting carddav sync with account" << m_accountId);
@@ -99,9 +99,10 @@ void Syncer::signInError()
     emit syncFailed();
 }
 
-void Syncer::sync(const QString &serverUrl, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors)
+void Syncer::sync(const QString &serverUrl, const QString &addressbookPath, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors)
 {
     m_serverUrl = serverUrl;
+    m_addressbookPath = addressbookPath;
     m_username = username;
     m_password = password;
     m_accessToken = accessToken;
@@ -123,8 +124,8 @@ void Syncer::sync(const QString &serverUrl, const QString &username, const QStri
 void Syncer::determineRemoteChanges(const QDateTime &, const QString &)
 {
     m_cardDav = m_username.isEmpty()
-              ? new CardDav(this, m_serverUrl, m_accessToken)
-              : new CardDav(this, m_serverUrl, m_username, m_password);
+              ? new CardDav(this, m_serverUrl, m_addressbookPath, m_accessToken)
+              : new CardDav(this, m_serverUrl, m_addressbookPath, m_username, m_password);
     connect(m_cardDav, SIGNAL(remoteChanges(QList<QContact>,QList<QContact>,QList<QContact>)),
             this, SLOT(continueSync(QList<QContact>,QList<QContact>,QList<QContact>)));
     connect(m_cardDav, SIGNAL(upsyncCompleted()),

--- a/src/syncer_p.h
+++ b/src/syncer_p.h
@@ -98,6 +98,7 @@ private:
     // auth related
     int m_accountId;
     QString m_serverUrl;
+    QString m_addressbookPath;
     QString m_username;
     QString m_password;
     QString m_accessToken;


### PR DESCRIPTION
This commit allows the initial path discovery steps to be skipped if
the user has specified the addressbook home set path during account
creation (relies on the "addressbook_path" account setting).

Contributes to MER#957