### PR TITLE
[buteo-sync-plugin-carddav] Don't restart daemon in %post. Contributes to MER#1044

### DIFF
--- a/rpm/buteo-sync-plugin-carddav.spec
+++ b/rpm/buteo-sync-plugin-carddav.spec
@@ -50,4 +50,4 @@ rm -rf %{buildroot}
 %qmake5_install
 
 %post
-su nemo -c "systemctl --user restart msyncd.service" || :
+echo "if you manually installed the package, you should invoke 'systemctl --user daemon-reload' and then 'systemctl --user restart msyncd'" || :


### PR DESCRIPTION
This commit ensures that we don't attempt to restart any daemon
via %post install section of .spec file.

Contributes to MER#1044