### PR TITLE
[buteo-sync-plugin-carddav] Improve addressbook-set parsing. Contributes to MER#1304

### DIFF
--- a/src/carddav.cpp
+++ b/src/carddav.cpp
@@ -541,7 +541,13 @@ void CardDav::downsyncAddressbookContent(const QList<ReplyParser::AddressBookInf
             q->m_defaultAddressbook = infos[i].url;
         }
 
-        if (infos[i].syncToken.isEmpty()) {
+        if (infos[i].syncToken.isEmpty() && infos[i].ctag.isEmpty()) {
+            // we cannot use either sync-token or ctag for this addressbook.
+            // we need to manually calculate the complete delta.
+            LOG_DEBUG("No sync-token or ctag given for addressbook:" << infos[i].url << ", manual delta detection required");
+            q->m_addressbookCtags[infos[i].url] = infos[i].ctag; // ctag is empty :. we will use manual detection.
+            fetchContactMetadata(infos[i].url);
+        } else if (infos[i].syncToken.isEmpty()) {
             // we cannot use sync-token for this addressbook, but instead ctag.
             const QString &existingCtag(q->m_addressbookCtags[infos[i].url]); // from OOB
             if (existingCtag.isEmpty()) {

--- a/src/carddav.cpp
+++ b/src/carddav.cpp
@@ -971,8 +971,16 @@ void CardDav::upsyncResponse()
         LOG_WARNING(Q_FUNC_INFO << "error:" << reply->error()
                    << "(" << httpError << ")");
         debugDumpData(QString::fromUtf8(data));
-        errorOccurred(httpError);
-        return;
+        if (httpError == 405) {
+            // MethodNotAllowed error.  Most likely the server has restricted
+            // new writes to the collection (e.g., read-only or update-only).
+            // We should not abort the sync if we receive this error.
+            LOG_WARNING(Q_FUNC_INFO << "405 MethodNotAllowed - is the collection read-only?");
+            LOG_WARNING(Q_FUNC_INFO << "continuing sync despite this error - upsync will have failed!");
+        } else {
+            errorOccurred(httpError);
+            return;
+        }
     }
 
     if (!guid.isEmpty()) {

--- a/src/requestgenerator.cpp
+++ b/src/requestgenerator.cpp
@@ -65,7 +65,11 @@ QNetworkReply *RequestGenerator::generateRequest(const QString &url,
         // this is because the initial URL may be a user-principals URL
         // but subsequent paths are not relative to that one, but instead
         // are relative to the root path /
-        reqUrl.setPath(path);
+        if (path.startsWith('/')) {
+            reqUrl.setPath(path);
+        } else {
+            reqUrl.setPath('/' + path);
+        }
     }
     if (!m_username.isEmpty() && !m_password.isEmpty()) {
         reqUrl.setUserName(m_username);


### PR DESCRIPTION
This commit adds support for parsing addressbook-set responses which
include multiple propstat elements.  Previously, this adapter assumed
that only one propstat per response would be returned.

Some services (e.g. Cozy) return multiple propstat elements, some with
404 NOT FOUND status values, in order to communicate the lack of some
non-essential properties (e.g., displayname).

Contributes to MER#1304